### PR TITLE
🐛 Details 페이지 콘솔로그 잔뜩 뜨던거 해결, key값 문제였음

### DIFF
--- a/src/components/detail/creatorReserveTap/CreatorReserveTap.js
+++ b/src/components/detail/creatorReserveTap/CreatorReserveTap.js
@@ -9,14 +9,14 @@ function CreatorReserveTap() {
   const [theme, setTheme] = useState(true);
   
   const [menuList, setMenuList] = useState([
-    { id: Date.now(), text: "모두" },
-    { id: Date.now(), text: "시리즈" },
-    { id: Date.now(), text: "blue rain 제공" },
-    { id: Date.now(), text: "관련 콘텐츠" },
-    { id: Date.now(), text: "blue rain 제공" },
-    { id: Date.now(), text: "관련 콘텐츠" },
-    { id: Date.now(), text: "blue rain 제공" },
-    { id: Date.now(), text: "관련 콘텐츠" },
+    {id : 1, text: "모두" },
+    {id : 2, text: "시리즈" },
+    {id : 3, text: "blue rain 제공" },
+    {id : 4, text: "관련 콘텐츠" },
+    {id : 5, text: "blue rain 제공" },
+    {id : 6, text: "관련 콘텐츠" },
+    {id : 7, text: "blue rain 제공" },
+    {id : 8, text: "관련 콘텐츠" },
   ]);
   const [video, setVideo] = useState([
     {
@@ -51,8 +51,8 @@ function CreatorReserveTap() {
         <span className={`right-arrow ${theme? light : dark}`}>{">"}</span>
       </div>
       {video && video.length > 0 ? (
-        video.map((video) => (
-          <div className='video-section' key={video.id}>
+        video.map((video, index) => (
+          <div className='video-section' key={index}>
             <div className='video-box'>
               <img src={video.videoSrc} alt='썸네일' className='video'></img>
               <span className='time-stamp'>{video.timestamp}</span>


### PR DESCRIPTION
오류 내용 캡쳐

![image](https://github.com/user-attachments/assets/dedabbc3-3483-44b1-99f0-efd6b6b49c97)
**원인 1**

```jsx
const [menuList, setMenuList] = useState([
    {id : Date.now(), text: "모두" },
    {id : Date.now(), text: "시리즈" },
    {id : Date.now(), text: "blue rain 제공" },
    {id : Date.now(), text: "관련 콘텐츠" },
    {id : Date.now(), text: "blue rain 제공" },
    {id : Date.now(), text: "관련 콘텐츠" },
    {id : Date.now(), text: "blue rain 제공" },
    {id : Date.now(), text: "관련 콘텐츠" },
  ]);
```

위와 같이 unique 값을 주려고 Date.now() 를 남발해버린 바람에 동시에 같은 시간의 키값이 들어가서 오류가 발생했음

```jsx
<div className='menu-list'>
       {menuList.map((menu) => (
	        <div className={`menu-item ${theme? light : dark}`} key={menu.id}>
            {menu.text}
          </div>
        ))}
</div>
```

해결 1

```jsx
  const [menuList, setMenuList] = useState([
    {id : 1, text: "모두" },
    {id : 2, text: "시리즈" },
    {id : 3, text: "blue rain 제공" },
    {id : 4, text: "관련 콘텐츠" },
    {id : 5, text: "blue rain 제공" },
    {id : 6, text: "관련 콘텐츠" },
    {id : 7, text: "blue rain 제공" },
    {id : 8, text: "관련 콘텐츠" },
  ]);
```

위와 같이 고유한 인덱스 값을 주었더니 콘솔 오류 1개는 사라짐

![image](https://github.com/user-attachments/assets/eb2e2970-1c46-401e-92ce-93f8a12dbe4d)

원인 2

이제 위 should have a unique “key” prop. 오류만 남았다

```jsx
const [video, setVideo] = useState([
    {
      title: "잠잘 때, 작업할 때 듣기좋은 시간대별 BGM 모음",
      channelName: "by. 채널명",
      viewerCount: 1600000,
      uploadDate: "4년전",
      videoSrc: "https://www.w3schools.com/howto/img_snow_wide.jpg",
      timestamp: "1:13:41",
    },
  ]);
  
  
  ...
  
  
  return (
	  video.map((video) => (
          <div className='video-section'>
            <div className='video-box'>
              <img src={video.videoSrc} alt='썸네일' className='video'></img>
              <span className='time-stamp'>{video.timestamp}</span>
            </div>
            <div className='video-details'>
              <div className={`video-title ${theme? light : dark}`}>{video.title}</div>
              <div className='channel-name'>{video.channelName}</div>
              <div className='video-info'>
                <span className='viewer-count'>
                  {formatViewerCount(video.viewerCount)}
                </span>
                <span className='upload-date'> {video.uploadDate}</span>
              </div>

              <img
                className='more-btn'
                src='assets/icon/more_btn.svg'
                alt='영상 더보기'
              />
            </div>
            {/* 테마 변경 테스트 */}
            {/* <button onClick={() => setTheme(!theme)}>딸깍</button> */}
          </div>
        ))
  )
```

video.map() 메소드를 사용할 때 video 객체가 배열이라 각각에 대한 키 값을 넣어주지 않아 발생한 문제였다.

해결2

```jsx
video.map((video, index) => (
          <div className='video-section' key={index}>
          
          ...
          
       
```

위 같이 map 에 index를 추가해주고 key값으로 index를 주었다

![image](https://github.com/user-attachments/assets/9f925ffc-6700-4a34-a0e2-01c1bd49cb1e)
콘솔로그가 깨끗해졌다